### PR TITLE
Galera.spec: remove scons

### DIFF
--- a/scripts/packages/galera.spec
+++ b/scripts/packages/galera.spec
@@ -53,12 +53,6 @@ BuildRoot:     %{_tmppath}/%{name}-%{version}
 BuildRequires: glibc-devel
 BuildRequires: openssl-devel
 
-%if 0%{?rhel} >= 8
-BuildRequires: python3-scons
-%else
-BuildRequires: scons
-%endif
-
 %if 0%{?suse_version} == 1110
 # On SLES11 SPx use the linked gcc47 to build instead of default gcc43
 #BuildRequires: gcc47 gcc47-c++


### PR DESCRIPTION
The building of RPMs assumes the code is already built. This may have been done with CMake. Having the build depends here can fail if scons isn't installed, despite is never used.